### PR TITLE
use userid (username) as profile:name

### DIFF
--- a/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
+++ b/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
@@ -255,7 +255,7 @@ export class CustomOAuth {
 				serviceData,
 				options: {
 					profile: {
-						name: identity.name || identity.username || identity.nickname || identity.CharacterName || identity.userName || identity.preferred_username || (identity.user && identity.user.name),
+						name: identity.name || identity.username || identity.nickname || identity.CharacterName || identity.userName || identity.preferred_username || (identity.user && identity.user.name) || identity.userid,
 					},
 				},
 			};

--- a/packages/rocketchat-ui-account/client/accountProfile.html
+++ b/packages/rocketchat-ui-account/client/accountProfile.html
@@ -14,7 +14,7 @@
 	<section class="preferences-page preferences-page--new">
 		{{#header sectionName="Profile" buttons=true fullpage=true}}
 			<div class="rc-header__section-button">
-				<button class="rc-button rc-button--primary" name="send" type="submit" data-button="create" form="profile" {{canSave 'disabled'}}>{{_ "Save_changes"}}</button>
+				<button class="rc-button rc-button--primary" name="send" type="submit" data-button="create" form="profile" {{canSave 'enabled'}}>{{_ "Save_changes"}}</button>
 			</div>
 		{{/header}}
 		<div class="preferences-page__content">

--- a/packages/rocketchat-ui-account/client/accountProfile.html
+++ b/packages/rocketchat-ui-account/client/accountProfile.html
@@ -97,36 +97,6 @@
 							</div>
 							{{/with}}
 						</div>
-						<!-- <div class="rc-form-group rc-grid">
-							{{#with canChange=allowEmailChange}}
-							<div class="rc-input rc-w50 padded {{#if emailInvalid}}rc-input--error{{/if}}">
-								<label class="rc-input__label">
-									<div class="rc-input__title">{{_ "Email"}}</div>
-									<div class="rc-input__wrapper">
-										<input name="email" type="text" class="rc-input__element" placeholder="{{_ "Email_Placeholder" }}" value="{{email}}" autocomplete="false" {{ifThenElse canChange '' 'disabled'}}>
-										{{#unless emailVerified}}
-											<div class="rc-input__icon rc-input__icon--right">
-												{{> icon block="rc-input__icon-svg" icon="cross-circled"}}
-											</div>
-										{{else}}
-											<div class="rc-input__icon rc-input__icon--right">
-												{{> icon block="rc-input__icon-svg" icon="checkmark-circled"}}
-											</div>
-										{{/unless}}
-									</div>
-								</label>
-								{{#unless canChange}}
-								{{!-- WIDECHAT --}}
-									{{!-- <div class="rc-input__description">{{_ 'Email_Change_Disabled'}}</div> --}}
-								{{/unless}}
-								{{#unless emailVerified}}
-									<div class="rc-input__error">
-										<button class="rc-button rc-button--small" id="resend-verification-email">{{_ "Resend_verification_email"}}</button>
-									</div>
-								{{/unless}}
-							</div>
-							{{/with}}
-						</div> -->
 					</div>
 				</fieldset>
 				<fieldset>

--- a/packages/rocketchat-ui-account/client/accountProfile.html
+++ b/packages/rocketchat-ui-account/client/accountProfile.html
@@ -97,7 +97,7 @@
 							</div>
 							{{/with}}
 						</div>
-						<div class="rc-form-group rc-grid">
+						<!-- <div class="rc-form-group rc-grid">
 							{{#with canChange=allowEmailChange}}
 							<div class="rc-input rc-w50 padded {{#if emailInvalid}}rc-input--error{{/if}}">
 								<label class="rc-input__label">
@@ -126,7 +126,7 @@
 								{{/unless}}
 							</div>
 							{{/with}}
-						</div>
+						</div> -->
 					</div>
 				</fieldset>
 				<fieldset>

--- a/packages/rocketchat-ui-account/client/accountProfile.js
+++ b/packages/rocketchat-ui-account/client/accountProfile.js
@@ -262,16 +262,17 @@ Template.accountProfile.onCreated(function() {
 				data.username = s.trim(self.username.get());
 			}
 		}
-		if (s.trim(self.email.get()) !== getUserEmailAddress(user)) {
-			if (!RocketChat.settings.get('Accounts_AllowEmailChange')) {
-				toastr.remove();
-				toastr.error(t('Email_Change_Disabled'));
-				instance.clearForm();
-				return cb && cb();
-			} else {
-				data.email = s.trim(self.email.get());
-			}
-		}
+		// WIDECHAT
+		// if (s.trim(self.email.get()) !== getUserEmailAddress(user)) {
+		// 	if (!RocketChat.settings.get('Accounts_AllowEmailChange')) {
+		// 		toastr.remove();
+		// 		toastr.error(t('Email_Change_Disabled'));
+		// 		instance.clearForm();
+		// 		return cb && cb();
+		// 	} else {
+		// 		data.email = s.trim(self.email.get());
+		// 	}
+		// }
 		const customFields = {};
 		$('[data-customfield=true]').each(function() {
 			customFields[this.name] = $(this).val() || '';

--- a/packages/rocketchat-ui-account/client/accountProfile.js
+++ b/packages/rocketchat-ui-account/client/accountProfile.js
@@ -125,7 +125,7 @@ Template.accountProfile.helpers({
 		}
 		// WIDECHAT - short circuit the validation checks to allow "Save Changes" on the Profile page.
 		return;
-		
+
 		if (!avatar && user.name === realname && user.username === username && getUserEmailAddress(user) === email === email && (!password || password !== confirmationPassword)) {
 			return ret;
 		}

--- a/packages/rocketchat-ui-account/client/accountProfile.js
+++ b/packages/rocketchat-ui-account/client/accountProfile.js
@@ -123,6 +123,9 @@ Template.accountProfile.helpers({
 				return;
 			}
 		}
+		// WIDECHAT - short circuit the validation checks to allow "Save Changes" on the Profile page.
+		return;
+		
 		if (!avatar && user.name === realname && user.username === username && getUserEmailAddress(user) === email === email && (!password || password !== confirmationPassword)) {
 			return ret;
 		}

--- a/packages/rocketchat-ui-account/client/accountProfile.js
+++ b/packages/rocketchat-ui-account/client/accountProfile.js
@@ -134,7 +134,7 @@ Template.accountProfile.helpers({
 			return;
 		}
 		// WIDECHAT dummy check
-		if (!user.username == username) {
+		if (!user.username === username) {
 			return ret;
 		}
 

--- a/packages/rocketchat-ui-account/client/accountProfile.js
+++ b/packages/rocketchat-ui-account/client/accountProfile.js
@@ -124,17 +124,9 @@ Template.accountProfile.helpers({
 			}
 		}
 		if (!avatar && user.name === realname && user.username === username && getUserEmailAddress(user) === email === email && (!password || password !== confirmationPassword)) {
-			// return ret;
-			// WIDECHAT short circuit
-			return;
+			return ret;
 		}
 		if (!validateEmail(email) || (!validateUsername(username) || usernameAvaliable !== true) || !validateName(realname)) {
-			// return ret;
-			// WIDECHAT short circuit
-			return;
-		}
-		// WIDECHAT dummy check
-		if (!user.username === username) {
 			return ret;
 		}
 

--- a/packages/rocketchat-ui-account/client/accountProfile.js
+++ b/packages/rocketchat-ui-account/client/accountProfile.js
@@ -133,6 +133,10 @@ Template.accountProfile.helpers({
 			// WIDECHAT short circuit
 			return;
 		}
+		// WIDECHAT dummy check
+		if (!user.username == username) {
+			return ret;
+		}
 
 		return;
 	},

--- a/packages/rocketchat-ui-account/client/accountProfile.js
+++ b/packages/rocketchat-ui-account/client/accountProfile.js
@@ -102,39 +102,40 @@ Template.accountProfile.helpers({
 	ifThenElse(condition, val, not = '') {
 		return condition ? val : not;
 	},
+	// WIDECHAT - short circuit all validation checks for allowing to save profile changes.
 	canSave(ret) {
-		const instance = Template.instance();
-		instance.dep.depend();
-		const realname = instance.realname.get();
-		const username = instance.username.get();
-		const password = instance.password.get();
-		const confirmationPassword = instance.confirmationPassword.get();
-		const email = instance.email.get();
-		const usernameAvaliable = instance.usernameAvaliable.get();
-		const avatar = instance.avatar.get();
-		const user = Meteor.user();
-		const { customFields = {} } = user;
-		if (instance.view.isRendered) {
-			if (instance.findAll('[data-customfield="true"]').some((el) => {
-				const key = el.getAttribute('name');
-				const value = customFields[key] || '';
-				return el.value !== value;
-			})) {
-				return;
-			}
-		}
-		// WIDECHAT - short circuit the validation checks to allow "Save Changes" on the Profile page.
-		return;
-
-		// if (!avatar && user.name === realname && user.username === username && getUserEmailAddress(user) === email === email && (!password || password !== confirmationPassword)) {
-		// 	return ret;
-		// }
-		// if (!validateEmail(email) || (!validateUsername(username) || usernameAvaliable !== true) || !validateName(realname)) {
-		// 	return ret;
-		// }
-
-		// return;
+		return true;
 	},
+	// canSave(ret) {
+	// 	const instance = Template.instance();
+	// 	instance.dep.depend();
+	// 	const realname = instance.realname.get();
+	// 	const username = instance.username.get();
+	// 	const password = instance.password.get();
+	// 	const confirmationPassword = instance.confirmationPassword.get();
+	// 	const email = instance.email.get();
+	// 	const usernameAvaliable = instance.usernameAvaliable.get();
+	// 	const avatar = instance.avatar.get();
+	// 	const user = Meteor.user();
+	// 	const { customFields = {} } = user;
+	// 	if (instance.view.isRendered) {
+	// 		if (instance.findAll('[data-customfield="true"]').some((el) => {
+	// 			const key = el.getAttribute('name');
+	// 			const value = customFields[key] || '';
+	// 			return el.value !== value;
+	// 		})) {
+	// 			return;
+	// 		}
+	// 	}
+	// 	if (!avatar && user.name === realname && user.username === username && getUserEmailAddress(user) === email === email && (!password || password !== confirmationPassword)) {
+	// 		return ret;
+	// 	}
+	// 	if (!validateEmail(email) || (!validateUsername(username) || usernameAvaliable !== true) || !validateName(realname)) {
+	// 		return ret;
+	// 	}
+
+	// 	return;
+	// },
 	allowDeleteOwnAccount() {
 		return RocketChat.settings.get('Accounts_AllowDeleteOwnAccount');
 	},

--- a/packages/rocketchat-ui-account/client/accountProfile.js
+++ b/packages/rocketchat-ui-account/client/accountProfile.js
@@ -102,40 +102,40 @@ Template.accountProfile.helpers({
 	ifThenElse(condition, val, not = '') {
 		return condition ? val : not;
 	},
-	// WIDECHAT - short circuit all validation checks for allowing to save profile changes.
 	canSave(ret) {
-		return true;
-	},
-	// canSave(ret) {
-	// 	const instance = Template.instance();
-	// 	instance.dep.depend();
-	// 	const realname = instance.realname.get();
-	// 	const username = instance.username.get();
-	// 	const password = instance.password.get();
-	// 	const confirmationPassword = instance.confirmationPassword.get();
-	// 	const email = instance.email.get();
-	// 	const usernameAvaliable = instance.usernameAvaliable.get();
-	// 	const avatar = instance.avatar.get();
-	// 	const user = Meteor.user();
-	// 	const { customFields = {} } = user;
-	// 	if (instance.view.isRendered) {
-	// 		if (instance.findAll('[data-customfield="true"]').some((el) => {
-	// 			const key = el.getAttribute('name');
-	// 			const value = customFields[key] || '';
-	// 			return el.value !== value;
-	// 		})) {
-	// 			return;
-	// 		}
-	// 	}
-	// 	if (!avatar && user.name === realname && user.username === username && getUserEmailAddress(user) === email === email && (!password || password !== confirmationPassword)) {
-	// 		return ret;
-	// 	}
-	// 	if (!validateEmail(email) || (!validateUsername(username) || usernameAvaliable !== true) || !validateName(realname)) {
-	// 		return ret;
-	// 	}
+		const instance = Template.instance();
+		instance.dep.depend();
+		const realname = instance.realname.get();
+		const username = instance.username.get();
+		const password = instance.password.get();
+		const confirmationPassword = instance.confirmationPassword.get();
+		const email = instance.email.get();
+		const usernameAvaliable = instance.usernameAvaliable.get();
+		const avatar = instance.avatar.get();
+		const user = Meteor.user();
+		const { customFields = {} } = user;
+		if (instance.view.isRendered) {
+			if (instance.findAll('[data-customfield="true"]').some((el) => {
+				const key = el.getAttribute('name');
+				const value = customFields[key] || '';
+				return el.value !== value;
+			})) {
+				return;
+			}
+		}
+		if (!avatar && user.name === realname && user.username === username && getUserEmailAddress(user) === email === email && (!password || password !== confirmationPassword)) {
+			// return ret;
+			// WIDECHAT short circuit
+			return;
+		}
+		if (!validateEmail(email) || (!validateUsername(username) || usernameAvaliable !== true) || !validateName(realname)) {
+			// return ret;
+			// WIDECHAT short circuit
+			return;
+		}
 
-	// 	return;
-	// },
+		return;
+	},
 	allowDeleteOwnAccount() {
 		return RocketChat.settings.get('Accounts_AllowDeleteOwnAccount');
 	},

--- a/packages/rocketchat-ui-account/client/accountProfile.js
+++ b/packages/rocketchat-ui-account/client/accountProfile.js
@@ -126,14 +126,14 @@ Template.accountProfile.helpers({
 		// WIDECHAT - short circuit the validation checks to allow "Save Changes" on the Profile page.
 		return;
 
-		if (!avatar && user.name === realname && user.username === username && getUserEmailAddress(user) === email === email && (!password || password !== confirmationPassword)) {
-			return ret;
-		}
-		if (!validateEmail(email) || (!validateUsername(username) || usernameAvaliable !== true) || !validateName(realname)) {
-			return ret;
-		}
+		// if (!avatar && user.name === realname && user.username === username && getUserEmailAddress(user) === email === email && (!password || password !== confirmationPassword)) {
+		// 	return ret;
+		// }
+		// if (!validateEmail(email) || (!validateUsername(username) || usernameAvaliable !== true) || !validateName(realname)) {
+		// 	return ret;
+		// }
 
-		return;
+		// return;
 	},
 	allowDeleteOwnAccount() {
 		return RocketChat.settings.get('Accounts_AllowDeleteOwnAccount');

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -31,7 +31,7 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 	}
 
 	if (serviceData.email) {
-		var user = RocketChat.models.Users.findOneByEmailAddress(serviceData.email);
+		let user = RocketChat.models.Users.findOneByEmailAddress(serviceData.email);
 		if (user != null) {
 			const findQuery = {
 				address: serviceData.email,
@@ -46,7 +46,7 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 			RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
 		} else {
 			// WIDECHAT
-			user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
+			let user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
 			if (user != null) {
 				RocketChat.models.Users.setServiceId(user._id, serviceName, serviceData.id);
 				RocketChat.models.Users.setEmail(user._id, serviceData.email);

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -31,9 +31,11 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 	}
 
 	// WIDECHAT
-	let user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
-	if (!user.name) {
-		RocketChat.models.Users.setName(user._id, serviceData.userid);
+	const user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
+	if (user != null) {
+		if (!user.name) {
+			RocketChat.models.Users.setName(user._id, serviceData.userid);
+		}
 	}
 
 	if (serviceData.email) {

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -30,6 +30,12 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 		serviceData.email = serviceData.emailAddress;
 	}
 
+	// WIDECHAT
+	let user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
+	if (!user.name) {
+		RocketChat.models.Users.setName(user._id, serviceData.userid);
+	}
+
 	if (serviceData.email) {
 		let user = RocketChat.models.Users.findOneByEmailAddress(serviceData.email);
 		if (user != null) {
@@ -52,10 +58,6 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 				RocketChat.models.Users.setEmail(user._id, serviceData.email);
 				RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
 			}
-		}
-		// WIDECHAT
-		if (!user.name) {
-			RocketChat.models.Users.setName(user._id, serviceData.userid);
 		}
 	}
 

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -51,6 +51,9 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 				RocketChat.models.Users.setServiceId(user._id, serviceName, serviceData.id);
 				RocketChat.models.Users.setEmail(user._id, serviceData.email);
 				RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
+				if (user.name == null) {
+					RocketChat.models.Users.setName(user._id, serviceData.userid);
+				}
 			}
 		}
 	}

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -51,9 +51,7 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 				RocketChat.models.Users.setServiceId(user._id, serviceName, serviceData.id);
 				RocketChat.models.Users.setEmail(user._id, serviceData.email);
 				RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
-				if (user.name == null) {
-					RocketChat.models.Users.setName(user._id, serviceData.userid);
-				}
+				RocketChat.models.Users.setName(user._id, serviceData.userid);
 			}
 		}
 	}

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -48,6 +48,9 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 			}
 
 			RocketChat.models.Users.setServiceId(user._id, serviceName, serviceData.id);
+			// WIDECHAT
+			RocketChat.models.Users.setEmail(user._id, serviceData.email);
+			
 			RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
 		}
 	}

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -33,10 +33,6 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 	if (serviceData.email) {
 		let user;
 		user = RocketChat.models.Users.findOneByEmailAddress(serviceData.email);
-		// WIDECHAT
-		if (user === null) {
-			user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
-		}
 		if (user != null) {
 			const findQuery = {
 				address: serviceData.email,
@@ -48,9 +44,15 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 			}
 
 			RocketChat.models.Users.setServiceId(user._id, serviceName, serviceData.id);
-			// WIDECHAT
-			RocketChat.models.Users.setEmail(user._id, serviceData.email);
 			RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
+		} else {
+			// WIDECHAT
+			user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
+			if (user != null) {
+				RocketChat.models.Users.setServiceId(user._id, serviceName, serviceData.id);
+				RocketChat.models.Users.setEmail(user._id, serviceData.email);
+				RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
+			}
 		}
 	}
 

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -31,8 +31,7 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 	}
 
 	if (serviceData.email) {
-		let user;
-		user = RocketChat.models.Users.findOneByEmailAddress(serviceData.email);
+		var user = RocketChat.models.Users.findOneByEmailAddress(serviceData.email);
 		if (user != null) {
 			const findQuery = {
 				address: serviceData.email,

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -50,7 +50,6 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 			RocketChat.models.Users.setServiceId(user._id, serviceName, serviceData.id);
 			// WIDECHAT
 			RocketChat.models.Users.setEmail(user._id, serviceData.email);
-			
 			RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
 		}
 	}

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -31,10 +31,11 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 	}
 
 	if (serviceData.email) {
-		const user = RocketChat.models.Users.findOneByEmailAddress(serviceData.email);
+		let user;
+		user = RocketChat.models.Users.findOneByEmailAddress(serviceData.email);
 		// WIDECHAT
 		if (user === null) {
-            user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
+			user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
 		}
 		if (user != null) {
 			const findQuery = {
@@ -47,7 +48,7 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 			}
 
 			RocketChat.models.Users.setServiceId(user._id, serviceName, serviceData.id);
-			RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);	
+			RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
 		}
 	}
 

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -46,7 +46,7 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 			RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
 		} else {
 			// WIDECHAT
-			let user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
+			user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
 			if (user != null) {
 				RocketChat.models.Users.setServiceId(user._id, serviceName, serviceData.id);
 				RocketChat.models.Users.setEmail(user._id, serviceData.email);

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -32,6 +32,10 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 
 	if (serviceData.email) {
 		const user = RocketChat.models.Users.findOneByEmailAddress(serviceData.email);
+		// WIDECHAT
+		if (user === null) {
+            user = RocketChat.models.Users.findOneByUsername(serviceData.userid);
+		}
 		if (user != null) {
 			const findQuery = {
 				address: serviceData.email,
@@ -43,7 +47,7 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 			}
 
 			RocketChat.models.Users.setServiceId(user._id, serviceName, serviceData.id);
-			RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
+			RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);	
 		}
 	}
 

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -51,8 +51,11 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 				RocketChat.models.Users.setServiceId(user._id, serviceName, serviceData.id);
 				RocketChat.models.Users.setEmail(user._id, serviceData.email);
 				RocketChat.models.Users.setEmailVerified(user._id, serviceData.email);
-				RocketChat.models.Users.setName(user._id, serviceData.userid);
 			}
+		}
+		// WIDECHAT
+		if (!user.name) {
+			RocketChat.models.Users.setName(user._id, serviceData.userid);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/WideChat/Rocket.Chat.Android/issues/301 by disabling the change email permissions check which gets called because some users will not have an email.
- Removes email from the profile page.  I suggest we make a new story to bring email and phone number back into that page, but only as plain text and not in a disabled text box.
- Enables the Save Changes button by default.
- Uses the username as the "name" by default.