### PR TITLE
aws-ecr/build-and-push-image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,9 @@ jobs:
             docker push rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER
 
 workflows:
-  version: 2
+  version: 2.1
+  orbs:
+    aws-ecr: circleci/aws-ecr@x.y.z
   build-and-test:
     jobs:
       - build:
@@ -409,25 +411,25 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - test-with-oplog-mongo-3-6: *test-mongo-no-pr
       - test-with-oplog-mongo-4-0: *test-mongo
-      - deploy:
-          requires:
-            - test-with-oplog-mongo-3-2
-            - test-with-oplog-mongo-3-4
-            - test-with-oplog-mongo-3-6
-            - test-with-oplog-mongo-4-0
-          filters:
-            branches:
-              only: develop
-            tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - image-build:
-          requires:
-            - deploy
-          filters:
-            branches:
-              only: develop
-            tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      # - deploy:
+      #     requires:
+      #       - test-with-oplog-mongo-3-2
+      #       - test-with-oplog-mongo-3-4
+      #       - test-with-oplog-mongo-3-6
+      #       - test-with-oplog-mongo-4-0
+      #     filters:
+      #       branches:
+      #         only: develop
+      #       tags:
+      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      # - image-build:
+      #     requires:
+      #       - deploy
+      #     filters:
+      #       branches:
+      #         only: develop
+      #       tags:
+      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - hold:
           type: approval
           requires:
@@ -437,12 +439,23 @@ workflows:
               ignore: develop
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - pr-image-build:
-          requires:
-            - hold
-          filters:
-            branches:
-              ignore: develop
-            tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      # - pr-image-build:
+      #     requires:
+      #       - hold
+      #     filters:
+      #       branches:
+      #         ignore: develop
+      #       tags:
+      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      - aws-ecr/build-and-push-image:
+              requires:
+                - hold
+              filters:
+                branches:
+                  ignore: develop
+              account-url: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+              repo: "${AWS_RESOURCE_NAME_PREFIX}"
+              region: ${AWS_DEFAULT_REGION}
+              tag: "${CIRCLE_SHA1}"
+              path: ~/repo/.docker/Dockerfile
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,8 @@ jobs:
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
           tag: ${CIRCLE_SHA1}
-          path: "/tmp/build-pr"
+          dockerfile: /tmp/build-pr/Dockerfile
+          # path: "/tmp/build-pr"
           checkout: false
 
             # docker login -u $DOCKER_USER -p $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,4 +477,4 @@ workflows:
               repo: ${AWS_RESOURCE_NAME_PREFIX}
               region: AWS_DEFAULT_REGION
               tag: ${CIRCLE_SHA1}
-              path: .docker
+              path: /home/circleci/project/.docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,25 +446,25 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      # - build:
-      #     filters:
-      #       tags:
-      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      # - test-with-oplog-mongo-3-4: &test-mongo
-      #     requires:
-      #       - build
-      #     filters:
-      #       tags:
-      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      # - test-with-oplog-mongo-3-6: &test-mongo-no-pr
-      #     requires:
-      #       - build
-      #     filters:
-      #       branches:
-      #         only: develop
-      #       tags:
-      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      # - test-with-oplog-mongo-4-0: *test-mongo
+      - build:
+          filters:
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      - test-with-oplog-mongo-3-4: &test-mongo
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      - test-with-oplog-mongo-3-6: &test-mongo-no-pr
+          requires:
+            - build
+          filters:
+            branches:
+              only: develop
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      - test-with-oplog-mongo-4-0: *test-mongo
       # - deploy:
       #     requires:
       #       - test-with-oplog-mongo-3-4
@@ -485,8 +485,8 @@ workflows:
       #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - hold:
           type: approval
-          # requires:
-          #   - build
+          requires:
+            - build
           filters:
             branches:
               ignore: develop
@@ -516,15 +516,3 @@ workflows:
               ignore: develop
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-
-      # - aws-ecr/build-and-push-image:
-      #         requires:
-      #           - hold
-      #         filters:
-      #           branches:
-      #             ignore: develop
-      #         account-url: AWS_ECR_ACCOUNT_URL
-      #         repo: ${AWS_RESOURCE_NAME_PREFIX}
-      #         region: AWS_DEFAULT_REGION
-      #         tag: ${CIRCLE_SHA1}
-      #         path: "/home/circleci/project/.docker/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,17 @@ test-install-dependencies: &test-install-dependencies
     echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
     sudo apt-get update
     sudo apt-get install -y mongodb-org-shell google-chrome-stable
+
 test-run: &test-run
   name: Run Tests
   command: |
     for i in $(seq 1 5); do mongo rocketchat --eval 'db.dropDatabase()' && npm test && s=0 && break || s=$? && sleep 1; done; (exit $s)
+
 test-npm-install: &test-npm-install
   name: NPM install
   command: |
     npm install
+
 test-store_artifacts: &test-store_artifacts
   path: .screenshots/
 
@@ -29,6 +32,7 @@ test-configure-replicaset: &test-configure-replicaset
   command: |
     mongo --eval 'rs.initiate({_id:"rs0", members: [{"_id":1, "host":"localhost:27017"}]})'
     mongo --eval 'rs.status()'
+
 test-restore-npm-cache: &test-restore-npm-cache
   keys:
     - node-modules-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "package.json" }}
@@ -59,6 +63,7 @@ test-with-oplog: &test-with-oplog
     - save_cache: *test-save-npm-cache
     - store_artifacts: *test-store_artifacts
 
+# WIDECHAT - using 2.1 and the aws orb to push docker images to ECR
 version: 2.1
 
 orbs:
@@ -100,6 +105,7 @@ jobs:
             fi
             # only install meteor if bin isn't found
             command -v meteor >/dev/null 2>&1 || curl https://install.meteor.com | sed s/--progress-bar/-sL/g | /bin/sh
+
       - run:
           name: Versions
           command: |
@@ -109,20 +115,25 @@ jobs:
             meteor npm --versions
             meteor node -v
             git version
+
       - run:
           name: Meteor npm install
           command: |
             # rm -rf node_modules
             # rm -f package-lock.json
             meteor npm install
+
+      # WIDECHAT TODO: uncomment after next upstream merge and resolve Lint failure
       # - run:
       #     name: Lint
       #     command: |
       #       meteor npm run lint
+
       - run:
           name: Unit Test
           command: |
             MONGO_URL=mongodb://localhost:27017 meteor npm run testunit
+
       - restore_cache:
           keys:
             - meteor-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum ".meteor/versions" }}
@@ -136,6 +147,7 @@ jobs:
             echo "" > client/main.js
             meteor build --server-only --debug --directory /tmp/build-temp
             git checkout -- server/main.js client/main.js
+
       - run:
           name: Build Rocket.Chat
           environment:
@@ -151,6 +163,7 @@ jobs:
               export METEOR_PROFILE=1000
               meteor build --server-only --directory --debug /tmp/build-test
             fi;
+
       - run:
           name: Prepare build
           command: |
@@ -159,6 +172,7 @@ jobs:
             tar czf /tmp/build/Rocket.Chat.tar.gz bundle
             cd /tmp/build-test/bundle/programs/server
             npm install
+
       - save_cache:
           key: node-modules-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "package.json" }}
           paths:
@@ -226,6 +240,7 @@ jobs:
             python3.5 get-pip.py --user
             export PATH=~/.local/bin:$PATH
             pip install awscli --upgrade --user
+
       - run:
           name: Publish assets
           command: |
@@ -241,12 +256,14 @@ jobs:
             bash .circleci/update-releases.sh
             bash .circleci/snap.sh
             bash .circleci/redhat-registry.sh
+
   image-build:
     <<: *defaults
 
     # docker:
     #   - image: docker:17.05.0-ce-git
 
+    # WIDECHAT - need to use ubuntu machine for the aws orb to work properly
     machine:
       image: ubuntu-1604:201903-01
 
@@ -256,6 +273,7 @@ jobs:
 
       - checkout
 
+      # WIDEHCAT - handled instead by the aws orb below
       # - setup_remote_docker
 
       - run:
@@ -281,6 +299,7 @@ jobs:
           dockerfile: /tmp/build/Dockerfile
           path: "/tmp/build-pr"
           checkout: false
+            # WIDECHAT 
             # if [[ $CIRCLE_TAG ]]; then
             #   docker login -u $DOCKER_USER -p $DOCKER_PASS
             #   echo "Build official Docker image"
@@ -318,6 +337,7 @@ jobs:
             #   docker push rocketchat/rocket.chat.preview:develop
             #   exit 0
             # fi;
+
   pr-build:
     <<: *defaults
     docker:
@@ -352,6 +372,7 @@ jobs:
             fi
             # only install meteor if bin isn't found
             command -v meteor >/dev/null 2>&1 || curl https://install.meteor.com | sed s/--progress-bar/-sL/g | /bin/sh
+
       - run:
           name: Versions
           command: |
@@ -361,12 +382,14 @@ jobs:
             meteor npm --versions
             meteor node -v
             git version
+
       - run:
           name: Meteor npm install
           command: |
             # rm -rf node_modules
             # rm -f package-lock.json
             meteor npm install
+
       - restore_cache:
           keys:
             - meteor-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum ".meteor/versions" }}
@@ -377,6 +400,7 @@ jobs:
             TOOL_NODE_FLAGS: --max_old_space_size=3072
           command: |
             meteor build --server-only /tmp/build-pr
+
       - persist_to_workspace:
           root: /tmp/
           paths:
@@ -391,6 +415,7 @@ jobs:
     # docker:
     #   - image: docker:17.05.0-ce-git
 
+    # WIDECHAT
     machine:
       image: ubuntu-1604:201903-01
 
@@ -400,6 +425,7 @@ jobs:
 
       - checkout
 
+      # WIDECHAT
       # - setup_remote_docker
 
       - run:
@@ -429,6 +455,7 @@ jobs:
           path: "/tmp/build-pr"
           checkout: false
 
+            # WIDECHAT
             # docker login -u $DOCKER_USER -p $DOCKER_PASS
             # echo "Build official Docker image"
             # cp ~/repo/.docker/Dockerfile .
@@ -439,6 +466,7 @@ jobs:
             # #cp ~/repo/.docker-mongo/entrypoint.sh .
             # #docker build -t rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER .
             # #docker push rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER
+
 workflows:
   version: 2
   build-and-test:
@@ -462,6 +490,7 @@ workflows:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - test-with-oplog-mongo-4-0: *test-mongo
+      # WIDECHAT
       # - deploy:
       #     requires:
       #       - test-with-oplog-mongo-3-4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,7 +409,7 @@ jobs:
           region: AWS_DEFAULT_REGION
           tag: ${CIRCLE_SHA1}
           dockerfile: /tmp/build-pr/Dockerfile
-          # path: "/tmp/build-pr"
+          path: "/tmp/build-pr"
           checkout: false
 
             # docker login -u $DOCKER_USER -p $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ jobs:
 
       - checkout
 
-      - setup_remote_docker
+      # - setup_remote_docker
 
       - run:
           name: Build Docker image
@@ -261,44 +261,52 @@ jobs:
             cd /tmp/build
             tar xzf Rocket.Chat.tar.gz
             rm Rocket.Chat.tar.gz
+            cp ~/repo/.docker/Dockerfile .
             export CIRCLE_TAG=${CIRCLE_TAG:=}
-            if [[ $CIRCLE_TAG ]]; then
-              docker login -u $DOCKER_USER -p $DOCKER_PASS
-              echo "Build official Docker image"
-              cp ~/repo/.docker/Dockerfile .
-              docker build -t rocketchat/rocket.chat:$CIRCLE_TAG .
-              docker push rocketchat/rocket.chat:$CIRCLE_TAG
-              echo "Build preview Docker image"
-              cp ~/repo/.docker-mongo/Dockerfile .
-              cp ~/repo/.docker-mongo/entrypoint.sh .
-              docker build -t rocketchat/rocket.chat.preview:$CIRCLE_TAG .
-              docker push rocketchat/rocket.chat.preview:$CIRCLE_TAG
-              if echo "$CIRCLE_TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' ; then
-                docker tag rocketchat/rocket.chat:$CIRCLE_TAG rocketchat/rocket.chat:latest
-                docker push rocketchat/rocket.chat:latest
-                docker tag rocketchat/rocket.chat.preview:$CIRCLE_TAG rocketchat/rocket.chat.preview:latest
-                docker push rocketchat/rocket.chat.preview:latest
-              elif echo "$CIRCLE_TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$' ; then
-                docker tag rocketchat/rocket.chat:$CIRCLE_TAG rocketchat/rocket.chat:release-candidate
-                docker push rocketchat/rocket.chat:release-candidate
-                docker tag rocketchat/rocket.chat.preview:$CIRCLE_TAG rocketchat/rocket.chat.preview:release-candidate
-                docker push rocketchat/rocket.chat.preview:release-candidate
-              fi
-              exit 0
-            fi;
-            if [[ $CIRCLE_BRANCH == 'develop' ]]; then
-              docker login -u $DOCKER_USER -p $DOCKER_PASS
-              echo "Build official Docker image"
-              cp ~/repo/.docker/Dockerfile .
-              docker build -t rocketchat/rocket.chat:develop .
-              docker push rocketchat/rocket.chat:develop
-              echo "Build preview Docker image"
-              cp ~/repo/.docker-mongo/Dockerfile .
-              cp ~/repo/.docker-mongo/entrypoint.sh .
-              docker build -t rocketchat/rocket.chat.preview:develop .
-              docker push rocketchat/rocket.chat.preview:develop
-              exit 0
-            fi;
+
+      - aws-ecr/build-and-push-image:
+          account-url: AWS_ECR_ACCOUNT_URL
+          repo: ${AWS_RESOURCE_NAME_PREFIX}
+          region: AWS_DEFAULT_REGION
+          tag: ${CIRCLE_TAG}
+          checkout: false
+            # if [[ $CIRCLE_TAG ]]; then
+            #   docker login -u $DOCKER_USER -p $DOCKER_PASS
+            #   echo "Build official Docker image"
+            #   cp ~/repo/.docker/Dockerfile .
+            #   docker build -t rocketchat/rocket.chat:$CIRCLE_TAG .
+            #   docker push rocketchat/rocket.chat:$CIRCLE_TAG
+            #   echo "Build preview Docker image"
+            #   cp ~/repo/.docker-mongo/Dockerfile .
+            #   cp ~/repo/.docker-mongo/entrypoint.sh .
+            #   docker build -t rocketchat/rocket.chat.preview:$CIRCLE_TAG .
+            #   docker push rocketchat/rocket.chat.preview:$CIRCLE_TAG
+            #   if echo "$CIRCLE_TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' ; then
+            #     docker tag rocketchat/rocket.chat:$CIRCLE_TAG rocketchat/rocket.chat:latest
+            #     docker push rocketchat/rocket.chat:latest
+            #     docker tag rocketchat/rocket.chat.preview:$CIRCLE_TAG rocketchat/rocket.chat.preview:latest
+            #     docker push rocketchat/rocket.chat.preview:latest
+            #   elif echo "$CIRCLE_TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$' ; then
+            #     docker tag rocketchat/rocket.chat:$CIRCLE_TAG rocketchat/rocket.chat:release-candidate
+            #     docker push rocketchat/rocket.chat:release-candidate
+            #     docker tag rocketchat/rocket.chat.preview:$CIRCLE_TAG rocketchat/rocket.chat.preview:release-candidate
+            #     docker push rocketchat/rocket.chat.preview:release-candidate
+            #   fi
+            #   exit 0
+            # fi;
+            # if [[ $CIRCLE_BRANCH == 'develop' ]]; then
+            #   docker login -u $DOCKER_USER -p $DOCKER_PASS
+            #   echo "Build official Docker image"
+            #   cp ~/repo/.docker/Dockerfile .
+            #   docker build -t rocketchat/rocket.chat:develop .
+            #   docker push rocketchat/rocket.chat:develop
+            #   echo "Build preview Docker image"
+            #   cp ~/repo/.docker-mongo/Dockerfile .
+            #   cp ~/repo/.docker-mongo/entrypoint.sh .
+            #   docker build -t rocketchat/rocket.chat.preview:develop .
+            #   docker push rocketchat/rocket.chat.preview:develop
+            #   exit 0
+            # fi;
   pr-build:
     <<: *defaults
     docker:
@@ -378,7 +386,7 @@ jobs:
 
       - checkout
 
-      - setup_remote_docker
+      # - setup_remote_docker
 
       - run:
           name: Build Docker image for PRs
@@ -390,12 +398,14 @@ jobs:
             cd /tmp/build-pr
             tar xzf repo.tar.gz
             rm repo.tar.gz
+            cp ~/repo/.docker/Dockerfile .
 
       - aws-ecr/build-and-push-image:
           account-url: AWS_ECR_ACCOUNT_URL
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
           tag: ${CIRCLE_SHA1}
+          checkout: false
 
             # docker login -u $DOCKER_USER -p $DOCKER_PASS
             # echo "Build official Docker image"
@@ -411,25 +421,25 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - build:
-          filters:
-            tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - test-with-oplog-mongo-3-4: &test-mongo
-          requires:
-            - build
-          filters:
-            tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - test-with-oplog-mongo-3-6: &test-mongo-no-pr
-          requires:
-            - build
-          filters:
-            branches:
-              only: develop
-            tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - test-with-oplog-mongo-4-0: *test-mongo
+      # - build:
+      #     filters:
+      #       tags:
+      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      # - test-with-oplog-mongo-3-4: &test-mongo
+      #     requires:
+      #       - build
+      #     filters:
+      #       tags:
+      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      # - test-with-oplog-mongo-3-6: &test-mongo-no-pr
+      #     requires:
+      #       - build
+      #     filters:
+      #       branches:
+      #         only: develop
+      #       tags:
+      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      # - test-with-oplog-mongo-4-0: *test-mongo
       # - deploy:
       #     requires:
       #       - test-with-oplog-mongo-3-4
@@ -455,6 +465,14 @@ workflows:
           filters:
             branches:
               ignore: develop
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      - image-build:
+          requires:
+            - hold
+          filters:
+            branches:
+              only: develop
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - pr-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,10 +115,10 @@ jobs:
             # rm -rf node_modules
             # rm -f package-lock.json
             meteor npm install
-      - run:
-          name: Lint
-          command: |
-            meteor npm run lint
+      # - run:
+      #     name: Lint
+      #     command: |
+      #       meteor npm run lint
       - run:
           name: Unit Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,8 +488,8 @@ workflows:
       #       tags:
       #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - pr-image-build:
-          requires:
-            - pr-build
+          # requires:
+          #   - pr-build
           filters:
             branches:
               ignore: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
       - run:
           name: Build a Meteor cache
           command: |
-            # to do this we can clear the main files and it build the rest
+            # to do this we can clear the main files and it builds the rest
             echo "" > server/main.js
             echo "" > client/main.js
             meteor build --server-only --debug --directory /tmp/build-temp
@@ -273,7 +273,7 @@ jobs:
 
       - checkout
 
-      # WIDEHCAT - handled instead by the aws orb below
+      # WIDECHAT - handled instead by the aws orb below
       # - setup_remote_docker
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,16 +390,23 @@ jobs:
             cd /tmp/build-pr
             tar xzf repo.tar.gz
             rm repo.tar.gz
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-            echo "Build official Docker image"
-            cp ~/repo/.docker/Dockerfile .
-            docker build -t rocketchat/rocket.chat:pr-$CIRCLE_PR_NUMBER .
-            docker push rocketchat/rocket.chat:pr-$CIRCLE_PR_NUMBER
-            #echo "Build preview Docker image"
-            #cp ~/repo/.docker-mongo/Dockerfile .
-            #cp ~/repo/.docker-mongo/entrypoint.sh .
-            #docker build -t rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER .
-            #docker push rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER
+
+      - aws-ecr/build-and-push-image:
+          account-url: AWS_ECR_ACCOUNT_URL
+          repo: ${AWS_RESOURCE_NAME_PREFIX}
+          region: AWS_DEFAULT_REGION
+          tag: ${CIRCLE_SHA1}
+
+            # docker login -u $DOCKER_USER -p $DOCKER_PASS
+            # echo "Build official Docker image"
+            # cp ~/repo/.docker/Dockerfile .
+            # docker build -t rocketchat/rocket.chat:pr-$CIRCLE_PR_NUMBER .
+            # docker push rocketchat/rocket.chat:pr-$CIRCLE_PR_NUMBER
+            # #echo "Build preview Docker image"
+            # #cp ~/repo/.docker-mongo/Dockerfile .
+            # #cp ~/repo/.docker-mongo/entrypoint.sh .
+            # #docker build -t rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER .
+            # #docker push rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER
 workflows:
   version: 2
   build-and-test:
@@ -458,23 +465,23 @@ workflows:
               ignore: develop
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      # - pr-image-build:
-      #     requires:
-      #       - pr-build
-      #     filters:
-      #       branches:
-      #         ignore: develop
-      #       tags:
-      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      - pr-image-build:
+          requires:
+            - pr-build
+          filters:
+            branches:
+              ignore: develop
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
 
-      - aws-ecr/build-and-push-image:
-              requires:
-                - hold
-              filters:
-                branches:
-                  ignore: develop
-              account-url: AWS_ECR_ACCOUNT_URL
-              repo: ${AWS_RESOURCE_NAME_PREFIX}
-              region: AWS_DEFAULT_REGION
-              tag: ${CIRCLE_SHA1}
-              path: /home/circleci/project/.docker
+      # - aws-ecr/build-and-push-image:
+      #         requires:
+      #           - hold
+      #         filters:
+      #           branches:
+      #             ignore: develop
+      #         account-url: AWS_ECR_ACCOUNT_URL
+      #         repo: ${AWS_RESOURCE_NAME_PREFIX}
+      #         region: AWS_DEFAULT_REGION
+      #         tag: ${CIRCLE_SHA1}
+      #         path: "/home/circleci/project/.docker/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -514,8 +514,8 @@ workflows:
           requires:
             - build
           filters:
-            branches:
-              ignore: develop
+          #   branches:
+          #     ignore: develop
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - image-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ test-with-oplog: &test-with-oplog
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@x.y.z
+  aws-ecr: circleci/aws-ecr@6.3.0
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,9 @@ jobs:
             export CIRCLE_TAG=${CIRCLE_TAG:=}
 
       - aws-ecr/build-and-push-image:
-          account-url: AWS_ECR_ACCOUNT_URL
+          account-url: AWS_PROD_ECR_ACCOUNT_URL
+          aws-access-key-id: AWS_PROD_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_PROD_SECRET_ACCESS_KEY
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
           tag: $(jq -r '.version' ~/repo/app/utils/rocketchat.info)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ jobs:
             meteor npm install
       - restore_cache:
           keys:
-            - meteor-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum ".meteor/versions" }
+            - meteor-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum ".meteor/versions" }}
 
       - run:
           name: Build Rocket.Chat
@@ -377,8 +377,16 @@ jobs:
   pr-image-build:
     <<: *defaults
 
-    docker:
-      - image: docker:17.05.0-ce-git
+    parameters:
+      image:
+        type: string
+        default: ubuntu-1604:201903-01
+
+    machine:
+      image: <<parameters.image>>
+
+    # docker:
+    #   - image: docker:17.05.0-ce-git
 
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,16 +377,11 @@ jobs:
   pr-image-build:
     <<: *defaults
 
-    parameters:
-      image:
-        type: string
-        default: ubuntu-1604:201903-01
-
-    machine:
-      image: <<parameters.image>>
-
     # docker:
     #   - image: docker:17.05.0-ce-git
+
+    machine:
+      image: ubuntu-1604:201903-01
 
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,7 @@ jobs:
           account-url: AWS_ECR_ACCOUNT_URL
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
-          tag: ${CIRCLE_PR_NUMBER}
+          tag: $(jq '.version' ~/repo/app/utils/rocketchat.info)
           dockerfile: /tmp/build-pr/Dockerfile
           path: "/tmp/build-pr"
           checkout: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,9 +455,9 @@ workflows:
               filters:
                 branches:
                   ignore: develop
-              account-url: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-              repo: "${AWS_RESOURCE_NAME_PREFIX}"
+              account-url: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+              repo: ${AWS_RESOURCE_NAME_PREFIX}
               region: ${AWS_DEFAULT_REGION}
-              tag: "${CIRCLE_SHA1}"
+              tag: ${CIRCLE_SHA1}
               path: ~/repo/.docker/Dockerfile
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,4 +477,4 @@ workflows:
               repo: ${AWS_RESOURCE_NAME_PREFIX}
               region: AWS_DEFAULT_REGION
               tag: ${CIRCLE_SHA1}
-              path: .docker/Dockerfile
+              path: .docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,11 @@ test-with-oplog: &test-with-oplog
     - save_cache: *test-save-npm-cache
     - store_artifacts: *test-store_artifacts
 
-version: 2
+version: 2.1
+
+orbs:
+  aws-ecr: circleci/aws-ecr@x.y.z
+
 jobs:
   build:
     <<: *defaults
@@ -386,9 +390,7 @@ jobs:
             docker push rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER
 
 workflows:
-  version: 2.1
-  orbs:
-    aws-ecr: circleci/aws-ecr@x.y.z
+  # version: 2
   build-and-test:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,7 @@ jobs:
           account-url: AWS_ECR_ACCOUNT_URL
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
-          tag: $(jq '.version' ~/repo/app/utils/rocketchat.info)
+          tag: $(jq -r '.version' ~/repo/app/utils/rocketchat.info)
           dockerfile: /tmp/build-pr/Dockerfile
           path: "/tmp/build-pr"
           checkout: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,14 +401,14 @@ jobs:
             cd /tmp/build-pr
             tar xzf repo.tar.gz
             rm repo.tar.gz
-            cp ~/repo/.docker/Dockerfile .
+            cp ~/repo/.docker/Dockerfile /tmp/build-pr
 
       - aws-ecr/build-and-push-image:
           account-url: AWS_ECR_ACCOUNT_URL
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
           tag: ${CIRCLE_SHA1}
-          path: /tmp/build-pr
+          path: "/tmp/build-pr"
           checkout: false
 
             # docker login -u $DOCKER_USER -p $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,8 +460,8 @@ workflows:
       #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - hold:
           type: approval
-          requires:
-            - build
+          # requires:
+          #   - build
           filters:
             branches:
               ignore: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,14 +271,13 @@ jobs:
             tar xzf Rocket.Chat.tar.gz
             rm Rocket.Chat.tar.gz
             cp ~/repo/.docker/Dockerfile /tmp/build
-            export WIDECHAT_SERVER_VERSION=$(jq '.version' ~/repo/app/utils/rocketchat.info)
             export CIRCLE_TAG=${CIRCLE_TAG:=}
 
       - aws-ecr/build-and-push-image:
           account-url: AWS_ECR_ACCOUNT_URL
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
-          tag: ${WIDECHAT_SERVER_VERSION}
+          tag: $(jq -r '.version' ~/repo/app/utils/rocketchat.info)
           dockerfile: /tmp/build/Dockerfile
           path: "/tmp/build-pr"
           checkout: false
@@ -420,14 +419,12 @@ jobs:
             tar xzf repo.tar.gz
             rm repo.tar.gz
             cp ~/repo/.docker/Dockerfile /tmp/build-pr
-            export WIDECHAT_SERVER_VERSION=$(jq '.version' ~/repo/app/utils/rocketchat.info)
-            echo $WIDECHAT_SERVER_VERSION
 
       - aws-ecr/build-and-push-image:
           account-url: AWS_ECR_ACCOUNT_URL
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
-          tag: $(jq -r '.version' ~/repo/app/utils/rocketchat.info)
+          tag: "pr-num-${CIRCLE_PULL_REQUEST##*/}"
           dockerfile: /tmp/build-pr/Dockerfile
           path: "/tmp/build-pr"
           checkout: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,9 +455,9 @@ workflows:
               filters:
                 branches:
                   ignore: develop
-              account-url: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+              account-url: AWS_ECR_ACCOUNT_URL
               repo: ${AWS_RESOURCE_NAME_PREFIX}
-              region: ${AWS_DEFAULT_REGION}
+              region: AWS_DEFAULT_REGION
               tag: ${CIRCLE_SHA1}
               path: ~/repo/.docker/Dockerfile
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,6 +408,7 @@ jobs:
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
           tag: ${CIRCLE_SHA1}
+          path: /tmp/build-pr
           checkout: false
 
             # docker login -u $DOCKER_USER -p $DOCKER_PASS
@@ -478,14 +479,14 @@ workflows:
               only: develop
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - pr-build:
-          requires:
-            - hold
-          filters:
-            branches:
-              ignore: develop
-            tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      # - pr-build:
+      #     requires:
+      #       - hold
+      #     filters:
+      #       branches:
+      #         ignore: develop
+      #       tags:
+      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - pr-image-build:
           requires:
             - pr-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,17 +13,14 @@ test-install-dependencies: &test-install-dependencies
     echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
     sudo apt-get update
     sudo apt-get install -y mongodb-org-shell google-chrome-stable
-
 test-run: &test-run
   name: Run Tests
   command: |
     for i in $(seq 1 5); do mongo rocketchat --eval 'db.dropDatabase()' && npm test && s=0 && break || s=$? && sleep 1; done; (exit $s)
-
 test-npm-install: &test-npm-install
   name: NPM install
   command: |
     npm install
-
 test-store_artifacts: &test-store_artifacts
   path: .screenshots/
 
@@ -32,7 +29,6 @@ test-configure-replicaset: &test-configure-replicaset
   command: |
     mongo --eval 'rs.initiate({_id:"rs0", members: [{"_id":1, "host":"localhost:27017"}]})'
     mongo --eval 'rs.status()'
-
 test-restore-npm-cache: &test-restore-npm-cache
   keys:
     - node-modules-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "package.json" }}
@@ -43,7 +39,7 @@ test-save-npm-cache: &test-save-npm-cache
     - ./node_modules
 
 test-docker-image: &test-docker-image
-  circleci/node:8.11-stretch-browsers
+  circleci/node:8.15-stretch-browsers
 
 test-with-oplog: &test-with-oplog
   <<: *defaults
@@ -72,8 +68,8 @@ jobs:
   build:
     <<: *defaults
     docker:
-      - image: circleci/node:8.11-stretch
-      - image: mongo:3.2
+      - image: circleci/node:8.15-stretch
+      - image: mongo:3.4
 
     steps:
       - checkout
@@ -102,10 +98,8 @@ jobs:
             else
               echo "No cached Meteor bin found."
             fi
-
             # only install meteor if bin isn't found
             command -v meteor >/dev/null 2>&1 || curl https://install.meteor.com | sed s/--progress-bar/-sL/g | /bin/sh
-
       - run:
           name: Versions
           command: |
@@ -115,39 +109,33 @@ jobs:
             meteor npm --versions
             meteor node -v
             git version
-
       - run:
           name: Meteor npm install
           command: |
             # rm -rf node_modules
             # rm -f package-lock.json
             meteor npm install
-            cd packages/rocketchat-livechat/.app
-            meteor npm install
-            cd -
-
       - run:
           name: Lint
           command: |
             meteor npm run lint
-
       - run:
           name: Unit Test
           command: |
             MONGO_URL=mongodb://localhost:27017 meteor npm run testunit
-
       - restore_cache:
           keys:
             - meteor-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum ".meteor/versions" }}
 
-      - restore_cache:
-          keys:
-            - livechat-meteor-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "packages/rocketchat-livechat/.app/.meteor/versions" }}
-
-      - restore_cache:
-          keys:
-            - livechat-node-modules-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "packages/rocketchat-livechat/.app/package.json" }}
-
+      # To reduce memory need during actual build, build the packages solely first
+      - run:
+          name: Build a Meteor cache
+          command: |
+            # to do this we can clear the main files and it build the rest
+            echo "" > server/main.js
+            echo "" > client/main.js
+            meteor build --server-only --debug --directory /tmp/build-temp
+            git checkout -- server/main.js client/main.js
       - run:
           name: Build Rocket.Chat
           environment:
@@ -156,7 +144,6 @@ jobs:
             if [[ $CIRCLE_TAG ]] || [[ $CIRCLE_BRANCH == 'develop' ]]; then
               meteor reset;
             fi
-
             export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
             if [[ -z $CIRCLE_PR_NUMBER ]]; then
               meteor build --server-only --directory /tmp/build-test
@@ -164,7 +151,6 @@ jobs:
               export METEOR_PROFILE=1000
               meteor build --server-only --directory --debug /tmp/build-test
             fi;
-
       - run:
           name: Prepare build
           command: |
@@ -173,7 +159,6 @@ jobs:
             tar czf /tmp/build/Rocket.Chat.tar.gz bundle
             cd /tmp/build-test/bundle/programs/server
             npm install
-
       - save_cache:
           key: node-modules-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "package.json" }}
           paths:
@@ -183,16 +168,6 @@ jobs:
           key: meteor-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum ".meteor/versions" }}
           paths:
             - ./.meteor/local
-
-      - save_cache:
-          key: livechat-node-modules-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "packages/rocketchat-livechat/.app/package.json" }}
-          paths:
-            - ./packages/rocketchat-livechat/app/node_modules
-
-      - save_cache:
-          key: livechat-meteor-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "packages/rocketchat-livechat/.app/.meteor/versions" }}
-          paths:
-            - ./packages/rocketchat-livechat/app/.meteor/local
 
       - save_cache:
           key: meteor-{{ checksum ".circleci/config.yml" }}-{{ checksum ".meteor/release" }}
@@ -208,13 +183,6 @@ jobs:
       - store_artifacts:
           path: /tmp/build
 
-
-  test-with-oplog-mongo-3-2:
-    <<: *test-with-oplog
-    docker:
-      - image: *test-docker-image
-      - image: mongo:3.2
-        command: [mongod, --noprealloc, --smallfiles, --replSet=rs0]
 
   test-with-oplog-mongo-3-4:
     <<: *test-with-oplog
@@ -240,7 +208,7 @@ jobs:
   deploy:
     <<: *defaults
     docker:
-      - image: circleci/node:8.11-stretch
+      - image: circleci/node:8.15-stretch
 
     steps:
       - attach_workspace:
@@ -252,34 +220,27 @@ jobs:
           name: Install AWS cli
           command: |
             if [[ $CIRCLE_PULL_REQUESTS ]]; then exit 0; fi;
-
             sudo apt-get -y -qq update
             sudo apt-get -y -qq install python3.5-dev
             curl -O https://bootstrap.pypa.io/get-pip.py
             python3.5 get-pip.py --user
             export PATH=~/.local/bin:$PATH
             pip install awscli --upgrade --user
-
-      # - run:
-      #     name: Publish assets
-      #     command: |
-      #       if [[ $CIRCLE_PULL_REQUESTS ]]; then exit 0; fi;
-
-      #       export PATH=~/.local/bin:$PATH
-      #       export CIRCLE_TAG=${CIRCLE_TAG:=}
-
-      #       source .circleci/setartname.sh
-      #       source .circleci/setdeploydir.sh
-      #       bash .circleci/setupsig.sh
-      #       bash .circleci/namefiles.sh
-      #       # echo ".circleci/sandstorm.sh"
-
-      #       aws s3 cp $ROCKET_DEPLOY_DIR/ s3://download.rocket.chat/build/ --recursive
-
-      #       bash .circleci/update-releases.sh
-      #       bash .circleci/snap.sh
-      #       bash .circleci/redhat-registry.sh
-
+      - run:
+          name: Publish assets
+          command: |
+            if [[ $CIRCLE_PULL_REQUESTS ]]; then exit 0; fi;
+            export PATH=~/.local/bin:$PATH
+            export CIRCLE_TAG=${CIRCLE_TAG:=}
+            aws s3 cp s3://rocketchat/sign.key.gpg .circleci/sign.key.gpg
+            source .circleci/setartname.sh
+            source .circleci/setdeploydir.sh
+            bash .circleci/setupsig.sh
+            bash .circleci/namefiles.sh
+            aws s3 cp $ROCKET_DEPLOY_DIR/ s3://download.rocket.chat/build/ --recursive
+            bash .circleci/update-releases.sh
+            bash .circleci/snap.sh
+            bash .circleci/redhat-registry.sh
   image-build:
     <<: *defaults
 
@@ -300,55 +261,110 @@ jobs:
             cd /tmp/build
             tar xzf Rocket.Chat.tar.gz
             rm Rocket.Chat.tar.gz
-
             export CIRCLE_TAG=${CIRCLE_TAG:=}
             if [[ $CIRCLE_TAG ]]; then
               docker login -u $DOCKER_USER -p $DOCKER_PASS
-
               echo "Build official Docker image"
               cp ~/repo/.docker/Dockerfile .
               docker build -t rocketchat/rocket.chat:$CIRCLE_TAG .
               docker push rocketchat/rocket.chat:$CIRCLE_TAG
-
               echo "Build preview Docker image"
               cp ~/repo/.docker-mongo/Dockerfile .
               cp ~/repo/.docker-mongo/entrypoint.sh .
               docker build -t rocketchat/rocket.chat.preview:$CIRCLE_TAG .
               docker push rocketchat/rocket.chat.preview:$CIRCLE_TAG
-
               if echo "$CIRCLE_TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' ; then
                 docker tag rocketchat/rocket.chat:$CIRCLE_TAG rocketchat/rocket.chat:latest
                 docker push rocketchat/rocket.chat:latest
-
                 docker tag rocketchat/rocket.chat.preview:$CIRCLE_TAG rocketchat/rocket.chat.preview:latest
                 docker push rocketchat/rocket.chat.preview:latest
               elif echo "$CIRCLE_TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$' ; then
                 docker tag rocketchat/rocket.chat:$CIRCLE_TAG rocketchat/rocket.chat:release-candidate
                 docker push rocketchat/rocket.chat:release-candidate
-
                 docker tag rocketchat/rocket.chat.preview:$CIRCLE_TAG rocketchat/rocket.chat.preview:release-candidate
                 docker push rocketchat/rocket.chat.preview:release-candidate
               fi
-
               exit 0
             fi;
-
             if [[ $CIRCLE_BRANCH == 'develop' ]]; then
               docker login -u $DOCKER_USER -p $DOCKER_PASS
-
               echo "Build official Docker image"
               cp ~/repo/.docker/Dockerfile .
               docker build -t rocketchat/rocket.chat:develop .
               docker push rocketchat/rocket.chat:develop
-
               echo "Build preview Docker image"
               cp ~/repo/.docker-mongo/Dockerfile .
               cp ~/repo/.docker-mongo/entrypoint.sh .
               docker build -t rocketchat/rocket.chat.preview:develop .
               docker push rocketchat/rocket.chat.preview:develop
-
               exit 0
             fi;
+  pr-build:
+    <<: *defaults
+    docker:
+      - image: circleci/node:8.15-stretch
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - node-modules-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "package.json" }}
+
+      - restore_cache:
+          keys:
+            - meteor-{{ checksum ".circleci/config.yml" }}-{{ checksum ".meteor/release" }}
+
+      - run:
+          name: Install Meteor
+          command: |
+            # Restore bin from cache
+            set +e
+            METEOR_SYMLINK_TARGET=$(readlink ~/.meteor/meteor)
+            METEOR_TOOL_DIRECTORY=$(dirname "$METEOR_SYMLINK_TARGET")
+            set -e
+            LAUNCHER=$HOME/.meteor/$METEOR_TOOL_DIRECTORY/scripts/admin/launch-meteor
+            if [ -e $LAUNCHER ]
+            then
+              echo "Cached Meteor bin found, restoring it"
+              sudo cp "$LAUNCHER" "/usr/local/bin/meteor"
+            else
+              echo "No cached Meteor bin found."
+            fi
+            # only install meteor if bin isn't found
+            command -v meteor >/dev/null 2>&1 || curl https://install.meteor.com | sed s/--progress-bar/-sL/g | /bin/sh
+      - run:
+          name: Versions
+          command: |
+            npm --versions
+            node -v
+            meteor --version
+            meteor npm --versions
+            meteor node -v
+            git version
+      - run:
+          name: Meteor npm install
+          command: |
+            # rm -rf node_modules
+            # rm -f package-lock.json
+            meteor npm install
+      - restore_cache:
+          keys:
+            - meteor-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum ".meteor/versions" }
+
+      - run:
+          name: Build Rocket.Chat
+          environment:
+            TOOL_NODE_FLAGS: --max_old_space_size=3072
+          command: |
+            meteor build --server-only /tmp/build-pr
+      - persist_to_workspace:
+          root: /tmp/
+          paths:
+            - build-pr
+
+      - store_artifacts:
+          path: /tmp/build-pr
 
   pr-image-build:
     <<: *defaults
@@ -371,39 +387,34 @@ jobs:
             if [[ -z $CIRCLE_PR_NUMBER ]]; then
               exit 0
             fi;
-
-            cd /tmp/build
-            tar xzf Rocket.Chat.tar.gz
-            rm Rocket.Chat.tar.gz
-
+            cd /tmp/build-pr
+            tar xzf repo.tar.gz
+            rm repo.tar.gz
             docker login -u $DOCKER_USER -p $DOCKER_PASS
-
             echo "Build official Docker image"
             cp ~/repo/.docker/Dockerfile .
             docker build -t rocketchat/rocket.chat:pr-$CIRCLE_PR_NUMBER .
             docker push rocketchat/rocket.chat:pr-$CIRCLE_PR_NUMBER
-
-            echo "Build preview Docker image"
-            cp ~/repo/.docker-mongo/Dockerfile .
-            cp ~/repo/.docker-mongo/entrypoint.sh .
-            docker build -t rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER .
-            docker push rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER
-
+            #echo "Build preview Docker image"
+            #cp ~/repo/.docker-mongo/Dockerfile .
+            #cp ~/repo/.docker-mongo/entrypoint.sh .
+            #docker build -t rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER .
+            #docker push rocketchat/rocket.chat.preview:pr-$CIRCLE_PR_NUMBER
 workflows:
-  # version: 2
+  version: 2
   build-and-test:
     jobs:
       - build:
           filters:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - test-with-oplog-mongo-3-2: &test-mongo
+      - test-with-oplog-mongo-3-4: &test-mongo
           requires:
             - build
           filters:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - test-with-oplog-mongo-3-4: &test-mongo-no-pr
+      - test-with-oplog-mongo-3-6: &test-mongo-no-pr
           requires:
             - build
           filters:
@@ -411,11 +422,9 @@ workflows:
               only: develop
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - test-with-oplog-mongo-3-6: *test-mongo-no-pr
       - test-with-oplog-mongo-4-0: *test-mongo
       # - deploy:
       #     requires:
-      #       - test-with-oplog-mongo-3-2
       #       - test-with-oplog-mongo-3-4
       #       - test-with-oplog-mongo-3-6
       #       - test-with-oplog-mongo-4-0
@@ -441,14 +450,23 @@ workflows:
               ignore: develop
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      - pr-build:
+          requires:
+            - hold
+          filters:
+            branches:
+              ignore: develop
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       # - pr-image-build:
       #     requires:
-      #       - hold
+      #       - pr-build
       #     filters:
       #       branches:
       #         ignore: develop
       #       tags:
       #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+
       - aws-ecr/build-and-push-image:
               requires:
                 - hold
@@ -459,5 +477,4 @@ workflows:
               repo: ${AWS_RESOURCE_NAME_PREFIX}
               region: AWS_DEFAULT_REGION
               tag: ${CIRCLE_SHA1}
-              path: ~/repo/.docker/Dockerfile
-
+              path: .docker/Dockerfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,17 +479,17 @@ workflows:
               only: develop
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      # - pr-build:
-      #     requires:
-      #       - hold
-      #     filters:
-      #       branches:
-      #         ignore: develop
-      #       tags:
-      #         only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
+      - pr-build:
+          requires:
+            - hold
+          filters:
+            branches:
+              ignore: develop
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - pr-image-build:
-          # requires:
-          #   - pr-build
+          requires:
+            - pr-build
           filters:
             branches:
               ignore: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,8 +244,11 @@ jobs:
   image-build:
     <<: *defaults
 
-    docker:
-      - image: docker:17.05.0-ce-git
+    # docker:
+    #   - image: docker:17.05.0-ce-git
+
+    machine:
+      image: ubuntu-1604:201903-01
 
     steps:
       - attach_workspace:
@@ -256,19 +259,28 @@ jobs:
       # - setup_remote_docker
 
       - run:
+          name: Install jq
+          command: |
+              sudo apt-get -y -qq update
+              sudo apt-get -y -qq install jq
+
+      - run:
           name: Build Docker image
           command: |
             cd /tmp/build
             tar xzf Rocket.Chat.tar.gz
             rm Rocket.Chat.tar.gz
-            cp ~/repo/.docker/Dockerfile .
+            cp ~/repo/.docker/Dockerfile /tmp/build
+            export WIDECHAT_SERVER_VERSION=$(jq '.version' ~/repo/app/utils/rocketchat.info)
             export CIRCLE_TAG=${CIRCLE_TAG:=}
 
       - aws-ecr/build-and-push-image:
           account-url: AWS_ECR_ACCOUNT_URL
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
-          tag: ${CIRCLE_TAG}
+          tag: ${WIDECHAT_SERVER_VERSION}
+          dockerfile: /tmp/build/Dockerfile
+          path: "/tmp/build-pr"
           checkout: false
             # if [[ $CIRCLE_TAG ]]; then
             #   docker login -u $DOCKER_USER -p $DOCKER_PASS
@@ -392,6 +404,12 @@ jobs:
       # - setup_remote_docker
 
       - run:
+          name: Install jq
+          command: |
+              sudo apt-get -y -qq update
+              sudo apt-get -y -qq install jq
+
+      - run:
           name: Build Docker image for PRs
           command: |
             export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
@@ -402,12 +420,13 @@ jobs:
             tar xzf repo.tar.gz
             rm repo.tar.gz
             cp ~/repo/.docker/Dockerfile /tmp/build-pr
+            export WIDECHAT_SERVER_VERSION=$(jq '.version' ~/repo/app/utils/rocketchat.info)
 
       - aws-ecr/build-and-push-image:
           account-url: AWS_ECR_ACCOUNT_URL
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
-          tag: ${CIRCLE_SHA1}
+          tag: ${WIDECHAT_SERVER_VERSION}
           dockerfile: /tmp/build-pr/Dockerfile
           path: "/tmp/build-pr"
           checkout: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,12 +421,13 @@ jobs:
             rm repo.tar.gz
             cp ~/repo/.docker/Dockerfile /tmp/build-pr
             export WIDECHAT_SERVER_VERSION=$(jq '.version' ~/repo/app/utils/rocketchat.info)
+            echo $WIDECHAT_SERVER_VERSION
 
       - aws-ecr/build-and-push-image:
           account-url: AWS_ECR_ACCOUNT_URL
           repo: ${AWS_RESOURCE_NAME_PREFIX}
           region: AWS_DEFAULT_REGION
-          tag: ${WIDECHAT_SERVER_VERSION}
+          tag: ${CIRCLE_PR_NUMBER}
           dockerfile: /tmp/build-pr/Dockerfile
           path: "/tmp/build-pr"
           checkout: false


### PR DESCRIPTION
- This PR adds support for a CircleCI "orb" to execute docker image uploads to our Elastic Container Repository in AWS, upon a push button approval after the "hold" job.  
- It also includes an upstream merge of just the circleCI config.yml file because there have been multiple optimizations that we needed from upstream in order to improve build consistency.  I've made comments in the file where the changes were WIDECHAT specific, which should help during subsequent upstream merges.