### PR TITLE
[Evo] Exposing per-message actions.

### DIFF
--- a/app/theme/client/imports/components/messages.css
+++ b/app/theme/client/imports/components/messages.css
@@ -205,3 +205,13 @@
 		}
 	}
 }
+
+@media (width < 500px) {
+	.message {
+		&:hover,
+		&.active {
+			background-color: rgba(15, 34, 0, 0.05);
+		}
+		user-select: none;
+	}
+}

--- a/app/ui-utils/client/lib/MessageAction.js
+++ b/app/ui-utils/client/lib/MessageAction.js
@@ -305,7 +305,7 @@ Meteor.startup(async function() {
 	if (isMobile()) {
 		MessageAction.addButton({
 			id: 'cancel-message',
-			icon: 'trash',
+			icon: 'cross',
 			label: 'Cancel',
 			context: ['message', 'message-mobile', 'threads'],
 			color: 'alert',
@@ -318,8 +318,8 @@ Meteor.startup(async function() {
 				}
 				return true;
 			},
-			order: 19,
-			group: 'menu',
+			order: 23,
+			group: 'message',
 		});
 	}
 	MessageAction.addButton({

--- a/app/ui-utils/client/lib/MessageAction.js
+++ b/app/ui-utils/client/lib/MessageAction.js
@@ -10,7 +10,7 @@ import { Tracker } from 'meteor/tracker';
 import { Session } from 'meteor/session';
 
 import { messageArgs } from './messageArgs';
-import { roomTypes, canDeleteMessage } from '../../../utils/client';
+import { roomTypes, canDeleteMessage, isMobile } from '../../../utils/client';
 import { Messages, Rooms, Subscriptions } from '../../../models/client';
 import { hasAtLeastOnePermission } from '../../../authorization/client';
 import { modal } from './modal';
@@ -302,6 +302,26 @@ Meteor.startup(async function() {
 		group: 'menu',
 	});
 
+	if (isMobile()) {
+		MessageAction.addButton({
+			id: 'cancel-message',
+			icon: 'trash',
+			label: 'Cancel',
+			context: ['message', 'message-mobile', 'threads'],
+			color: 'alert',
+			action() {
+				// empty action closes the popover
+			},
+			condition({ subscription }) {
+				if (!subscription) {
+					return false;
+				}
+				return true;
+			},
+			order: 19,
+			group: 'menu',
+		});
+	}
 	MessageAction.addButton({
 		id: 'report-message',
 		icon: 'report',

--- a/app/utils/client/index.js
+++ b/app/utils/client/index.js
@@ -20,3 +20,4 @@ export { templateVarHandler } from '../lib/templateVarHandler';
 export { APIClient } from './lib/RestApiClient';
 export { canDeleteMessage } from './lib/canDeleteMessage';
 export { mime } from '../lib/mimeTypes';
+export { isMobile } from './lib/isMobile';

--- a/app/utils/client/lib/isMobile.js
+++ b/app/utils/client/lib/isMobile.js
@@ -1,0 +1,6 @@
+export const isMobile = () => {
+	if (/Mobi/.test(navigator.userAgent)) {
+		return true;
+	}
+	return false;
+};


### PR DESCRIPTION
This PR attempts to fix [#23](https://github.com/WideChat/pwa/issues/23)
Earlier long pressing on a message was opening the message-actions menu which was not intuitive.
Changes: 

- When you tap on a message it will change its color just like when you hover on the web client.
- Earlier, on long pressing a message some part of the text was also being selected (apart from opening the message-actions menu), this is fixed.
- Added a `Cancel` button in the message-actions to close the message-actions menu. (As in native app)