### PR TITLE
Making check mark visible in read-receipts.

### DIFF
--- a/imports/message-read-receipt/client/readReceipts.css
+++ b/imports/message-read-receipt/client/readReceipts.css
@@ -5,8 +5,12 @@
 }
 
 .read-receipt .rc-icon {
-	height: 0.8em;
-	width: 0.8em;
+	height: 1em;
+	width: 1em;
+}
+/* Overwriting the color-component-color class defined in colors.less */
+.color-component-color {
+	color: grey;
 }
 
 .message:hover .read-receipt, .message.active .read-receipt {


### PR DESCRIPTION
Fixes [26](https://github.com/WideChat/pwa/issues/26)
<br>
<br>
Updated check-marks look like this. These are the unread check-marks. Read check-mark have not been changed.
<img src="https://user-images.githubusercontent.com/34206972/69670978-1f671700-10bb-11ea-959f-6b5df5e72858.PNG" width="400" height="auto" height="200" />

