### PR TITLE
[WIP] Dynamic Import of Markdown.

### DIFF
--- a/app/markdown/client/index.js
+++ b/app/markdown/client/index.js
@@ -1,1 +1,1 @@
-export { Markdown } from '../lib/markdown';
+export { Markdown, MarkdownMessage } from '../lib/markdown';

--- a/app/markdown/lib/markdown.js
+++ b/app/markdown/lib/markdown.js
@@ -81,7 +81,8 @@ class MarkdownClass {
 export const Markdown = new MarkdownClass();
 
 // renderMessage already did html escape
-const MarkdownMessage = (message) => {
+export const MarkdownMessage = (message) => {
+	console.log('in the markdownmessage fn');
 	if (s.trim(message != null ? message.html : undefined)) {
 		message = Markdown.parseMessageNotEscaped(message);
 	}
@@ -89,7 +90,7 @@ const MarkdownMessage = (message) => {
 	return message;
 };
 
-callbacks.add('renderMessage', MarkdownMessage, callbacks.priority.HIGH, 'markdown');
+// callbacks.add('renderMessage', MarkdownMessage, callbacks.priority.HIGH, 'markdown');
 
 if (Meteor.isClient) {
 	Blaze.registerHelper('RocketChatMarkdown', (text) => Markdown.parse(text));

--- a/app/ui-utils/client/lib/renderMessageBody.js
+++ b/app/ui-utils/client/lib/renderMessageBody.js
@@ -25,11 +25,15 @@ const mem = (fn, tm = 500, generateKey = generateKeyDefault) => {
 	};
 };
 
-export const renderMessageBody = mem((message) => {
+export const renderMessageBody = mem((message, runMarkdown = true, markdownFn = null) => {
 	message.html = s.trim(message.msg) ? s.escapeHTML(message.msg) : '';
-
-	const { tokens, html } = callbacks.run('renderMessage', message);
-
+	let tokens;
+	let html;
+	if (runMarkdown && markdownFn) {
+		({ tokens, html } = callbacks.run('renderMessage', markdownFn(message)));
+	} else {
+		({ tokens, html } = callbacks.run('renderMessage', message));
+	}
 	return (Array.isArray(tokens) ? tokens.reverse() : [])
 		.reduce((html, { token, text }) => html.replace(token, () => text), html);
 }, 500, ({ _id, _updatedAt }) => _id && _updatedAt && _id + _updatedAt);


### PR DESCRIPTION
Fixes [60](https://github.com/WideChat/pwa/issues/60). 
Description: 

 Since `highlight.js` is mainly used by the markdown package.
 I am first trying to render all messages without markdown. In the meanwhile `markdown` is imported and I plan use it to re-render the messages. 
The main issue which i am facing is  that messages are not being re-rendered after importing _unless_ we do some action on it, such as `starring`, `pinning`. I am unable to find the cause of this. Help is appreciated.
If done right, this can reduce around 0.7 MB of the initial client size and we can omit sending it to the mobile/pwa.