### PR TITLE
Change Attach/Upload File Icon

### DIFF
--- a/app/ui-message/client/messageBox/messageBoxActions.js
+++ b/app/ui-message/client/messageBox/messageBoxActions.js
@@ -25,7 +25,7 @@ messageBox.actions.add('Create_new', 'Video_message', {
 
 messageBox.actions.add('Add_files_from', 'Computer', {
 	id: 'file-upload',
-	icon: 'computer',
+	icon: 'clip',
 	condition: () => settings.get('FileUpload_Enabled'),
 	action({ rid, tmid, event, messageBox }) {
 		event.preventDefault();


### PR DESCRIPTION
Closes https://github.com/WideChat/pwa/issues/52

You can see attachment icon at bottom.

<img width="418" alt="Screenshot 2020-01-19 at 3 39 11 PM" src="https://user-images.githubusercontent.com/18264684/72679143-5ca3c000-3ad2-11ea-86c6-f17f60cfe318.png">
