### PR TITLE
[NEW] Add Statusbar Color

### DIFF
--- a/app/ui-master/server/inject.js
+++ b/app/ui-master/server/inject.js
@@ -66,7 +66,6 @@ Meteor.startup(() => {
 	});
 
 	settings.get('theme-color-rc-color-primary', (key, value) => {
-		console.log({ key, value });
 		const escapedValue = s.escapeHTML(value);
 		injectIntoHead(key, `<meta name="msapplication-TileColor" content="${ escapedValue }" />`
 							+ `<meta name="theme-color" content="${ escapedValue }" />`);

--- a/app/ui-master/server/inject.js
+++ b/app/ui-master/server/inject.js
@@ -65,7 +65,8 @@ Meteor.startup(() => {
 		}
 	});
 
-	settings.get('theme-color-sidebar-background', (key, value) => {
+	settings.get('theme-color-rc-color-primary', (key, value) => {
+		console.log({ key, value });
 		const escapedValue = s.escapeHTML(value);
 		injectIntoHead(key, `<meta name="msapplication-TileColor" content="${ escapedValue }" />`
 							+ `<meta name="theme-color" content="${ escapedValue }" />`);

--- a/client/head.html
+++ b/client/head.html
@@ -13,6 +13,13 @@
 	<meta name="msapplication-config" content="images/browserconfig.xml" />
 	<meta property="og:image" content="assets/favicon_512.png" />
 	<meta property="twitter:image" content="assets/favicon_512.png" />
+
+	<!-- Chrome, Firefox OS and Opera -->
+	<meta name="theme-color" content="#0B6379"/>
+
+	<!-- iOS -->
+	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
+
 	<link rel="manifest" href="manifest.json" />
 	<link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/nocfbnnmjnndkbipkabodnheejiegccf" />
 	<link rel="mask-icon" href="assets/safari_pinned.svg" color="#04436a">

--- a/client/head.html
+++ b/client/head.html
@@ -14,9 +14,6 @@
 	<meta property="og:image" content="assets/favicon_512.png" />
 	<meta property="twitter:image" content="assets/favicon_512.png" />
 
-	<!-- Chrome, Firefox OS and Opera -->
-	<meta name="theme-color" content="#0B6379"/>
-
 	<!-- iOS -->
 	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,6 +2,7 @@
     "name": "Viasat Connect",
     "short_name": "Viasat Connect",
     "background_color": "#0B6379",
+    "theme_color":"#0B6379",
     "icons": [
         {
             "src": "images/icons/icon-72x72.png",


### PR DESCRIPTION
Closes https://github.com/WideChat/Rocket.Chat/issues/192

- [x] Add theme_color (To show statusbar color when standalone pwa is installed) 
- [x] Add meta tag theme-color (To show statusbar color when client is open in mobile browser)

**In Browser**
![Screenshot_1585069431](https://user-images.githubusercontent.com/18264684/77455975-99689c00-6e20-11ea-8216-8a443ae99f59.png)

**In Standalone PWA**
![Screenshot_1585069466](https://user-images.githubusercontent.com/18264684/77455992-9cfc2300-6e20-11ea-98d3-1da24d438ab7.png)

