### PR TITLE
Set Admin Rooms Users Similar to Upstream

### DIFF
--- a/client/importPackages.js
+++ b/client/importPackages.js
@@ -73,7 +73,7 @@ import '../app/spotify/client';
 import '../app/tokenpass/client';
 import '../app/ui';
 import '../app/ui-account';
-// import '../app/ui-admin/client';
+import '../app/ui-admin/client';
 import '../app/ui-clean-history';
 import '../app/ui-flextab';
 import '../app/ui-login';

--- a/client/routes.js
+++ b/client/routes.js
@@ -233,22 +233,6 @@ FlowRouter.route('/setup-wizard/:step?', {
 	},
 });
 
-FlowRouter.route('/admin/users', {
-	name: 'admin-users',
-	async action() {
-		await import('../app/ui-admin/client/users/views');
-		BlazeLayout.render('main', { center: 'adminUsers' });
-	},
-});
-
-FlowRouter.route('/admin/rooms', {
-	name: 'admin-rooms',
-	async action() {
-		await import('../app/ui-admin/client/rooms/views');
-		BlazeLayout.render('main', { center: 'adminRooms' });
-	},
-});
-
 const style = 'overflow: hidden; flex: 1 1 auto; height: 1%;';
 FlowRouter.route('/admin/:group?', {
 	name: 'admin',


### PR DESCRIPTION
Closes https://github.com/WideChat/Rocket.Chat/issues/196 https://github.com/WideChat/Rocket.Chat/issues/205

Upstream is not using React in Admin Users/Rooms. So https://github.com/WideChat/Rocket.Chat/pull/204 is not actually temp fix(It is similar to upstream). I have updated code to make it parallel to upstream.
