### PR TITLE
[Upstream PWA] #17375 Make Sidebar FullScreen For PWA

### DIFF
--- a/app/theme/client/imports/components/main-content.css
+++ b/app/theme/client/imports/components/main-content.css
@@ -2,7 +2,7 @@
 
 	position: relative;
 
-	z-index: 0;
+	z-index: 2;
 
 	display: flex;
 	flex-direction: column;
@@ -11,6 +11,9 @@
 	width: 1vw;
 
 	height: 100%;
+
+	transition: transform 0.3s;
+	transform: translate3d(100%, 0, 0);
 }
 
 .messages-container .room-icon {

--- a/app/theme/client/imports/components/sidebar/sidebar.css
+++ b/app/theme/client/imports/components/sidebar/sidebar.css
@@ -2,13 +2,13 @@
 
 	position: relative;
 
-	z-index: 2;
+	z-index: 0;
 
 	display: flex;
 	flex-direction: column;
 	flex: 0 0 var(--sidebar-width);
 
-	width: var(--sidebar-width);
+	width: 100%;
 	max-width: var(--sidebar-width);
 
 	height: 100%;
@@ -71,11 +71,13 @@
 @media (width < 780px) {
 	.sidebar {
 		position: absolute;
+
+		max-width: none;
 	}
 
 	.sidebar:not(.sidebar-light) {
 		user-select: none;
-		transform: translate3d(-100%, 0, 0);
+		transform: translate3d(0, 0, 0);
 		-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 		touch-action: pan-y;
 		-webkit-user-drag: none;
@@ -91,15 +93,16 @@
 	.sidebar {
 		flex: 0 0 var(--sidebar-small-width);
 
-		width: var(--sidebar-small-width);
-		max-width: var(--sidebar-small-width);
+		width: 100%;
+
+		max-width: none;
 
 		&__footer {
 			display: none;
 		}
 
 		&:not(&--light) {
-			transform: translate3d(-100%, 0, 0);
+			transform: translate3d(0, 0, 0);
 		}
 	}
 

--- a/app/ui-utils/client/lib/menu.js
+++ b/app/ui-utils/client/lib/menu.js
@@ -1,3 +1,4 @@
+import { FlowRouter } from 'meteor/kadira:flow-router';
 import { Session } from 'meteor/session';
 import { Meteor } from 'meteor/meteor';
 import _ from 'underscore';
@@ -116,11 +117,16 @@ export const menu = new class extends EventEmitter {
 		if (diff === undefined) {
 			diff = this.isRtl ? -1 * sideNavW : sideNavW;
 		}
-		this.sidebarWrap.css('width', '100%');
+
 		this.wrapper.css('overflow', 'hidden');
+
+		this.sidebarWrap.css('width', '100%');
+		this.sidebarWrap.css('z-index', '1');
 		this.sidebarWrap.css('background-color', '#000');
-		this.sidebarWrap.css('opacity', map(Math.abs(diff) / width, 0, 1, -0.1, 0.8).toFixed(2));
-		this.isRtl ? this.sidebar.css('transform', `translate3d(${ (sideNavW + diff).toFixed(3) }px, 0 , 0)`) : this.sidebar.css('transform', `translate3d(${ (diff - sideNavW).toFixed(3) }px, 0 , 0)`);
+		this.sidebarWrap.css('opacity', map(Math.abs(diff) / width, 0, 1, 0.8, -0.1).toFixed(2));
+
+		// Translate main content
+		this.isRtl ? this.mainContent.css('transform', `translate3d(${ - diff.toFixed(3) }px, 0 , 0)`) : this.mainContent.css('transform', `translate3d(${ diff.toFixed(3) }px, 0 , 0)`);
 	}
 
 	touchend() {
@@ -154,6 +160,8 @@ export const menu = new class extends EventEmitter {
 		this.sidebar = this.menu;
 		this.sidebarWrap = $('.sidebar-wrap');
 		this.wrapper = $('.messages-box > .wrapper');
+		this.mainContent = $('.main-content');
+
 		const ignore = (fn) => (event) => document.body.clientWidth <= 780 && fn(event);
 
 		document.body.addEventListener('touchstart', ignore((e) => this.touchstart(e)));
@@ -163,21 +171,20 @@ export const menu = new class extends EventEmitter {
 			e.target === this.sidebarWrap[0] && this.isOpen() && this.emit('clickOut', e);
 		}));
 		this.on('close', () => {
-			this.sidebarWrap.css('width', '');
-			// this.sidebarWrap.css('z-index', '');
-			this.sidebarWrap.css('background-color', '');
-			this.sidebar.css('transform', '');
-			this.sidebar.css('box-shadow', '');
-			this.sidebar.css('transition', '');
-			this.sidebarWrap.css('transition', '');
-			this.wrapper && this.wrapper.css('overflow', '');
+			// Open main content
+			this.mainContent.css('transform', 'translate3d( 0, 0 , 0)');
 		});
 		this.on('open', ignore(() => {
-			this.sidebar.css('box-shadow', '0 0 15px 1px rgba(0,0,0,.3)');
-			// this.sidebarWrap.css('z-index', '9998');
-			this.translate();
+			this.sidebarWrap.css('width', '');
+			this.sidebarWrap.css('z-index', '');
+			this.sidebarWrap.css('background-color', '');
+
+			// Close main content
+			this.mainContent.css('transform', 'translate3d( 100%, 0 , 0)');
+			FlowRouter.withReplaceState(function() {
+				FlowRouter.go('/home');
+			});
 		}));
-		this.mainContent = $('.main-content');
 
 		this.list = $('.rooms-list');
 		this._open = false;


### PR DESCRIPTION
This is 4th Feature of https://github.com/WideChat/Rocket.Chat/wiki/PWA-features to integrate PWA functionality in RC.

The goal of this PR is to make RC on Mobile device to give similar experience as Native App. Which have home screen with all chats. We can do it by making Sidebar FullScreen.

- [x] Make Width of Sidebar Width 100%(To make it as home Screen)
- [x] Main Content will slide in from Right on top of Sidebar(home) when user clicks on chat. (Earlier Sidebar was sliding in from left on top of Main Content)
- [x] When chat is open, swiping from left to right slides main content and closes it, and user goes to Sidebar(home)

**Demo**
![Screen-Recording-2020-05-03-at-1](https://user-images.githubusercontent.com/18264684/80921993-a9688980-8d97-11ea-8589-6c758afa7485.gif)