### PR TITLE
Cache user avatar without '_dc' params

### DIFF
--- a/app/ui-utils/client/lib/avatar.js
+++ b/app/ui-utils/client/lib/avatar.js
@@ -39,5 +39,8 @@ export const updateAvatarOfUsername = function(username) {
 	$(`.sidebar-item.js-sidebar-type-d .sidebar-item__link[aria-label='${ username }'] .avatar-image`)
 		.attr('src', url);
 
+	// force reload of avatar on sidenav header
+	$(`.sidebar__header .sidebar__header-thumb .avatar-image[alt='${ username }']`).attr('src', url);
+
 	return true;
 };

--- a/public/sw.js
+++ b/public/sw.js
@@ -15,6 +15,12 @@ function hasSameHash(firstUrl, secondUrl) {
 	}
 }
 
+function handleAvatar(request, response) {
+	const clonedResponse = response.clone();
+	const url = request.url.split('?')[0];
+	caches.open(version).then((cache) => cache.put(new Request(url), clonedResponse));
+}
+
 const fetchFromNetwork = (event) => {
 	const requestToFetch = event.request.clone();
 	return fetch(requestToFetch, { cache: 'reload' }).then((response) => {
@@ -37,6 +43,12 @@ const fetchFromNetwork = (event) => {
 					}
 				})));
 			}
+
+			if (/avatar\/.*\?_dc/.test(event.request.url)) {
+				// handle the avatar updates
+				handleAvatar(event.request, response);
+			}
+
 			caches.open(version).then((cache) => cache.put(event.request, clonedResponse));
 		}
 		return response;


### PR DESCRIPTION
Closes #274 

This PR solves the update of the avatar. Except for the top thumbnail, which somehow shows a blank box after new avatar. 
While testing this PR, please wait for a few seconds before refreshing, to avoid [this](https://drive.google.com/file/d/17l_clh6-3BxPcVx-zLNQ5RiIDh-c73UD/view?usp=sharing) issue.