### PR TITLE
[FIX] upgrade apps-engine to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2849,9 +2849,9 @@
 			}
 		},
 		"@rocket.chat/apps-engine": {
-			"version": "1.13.0-beta.3003",
-			"resolved": "https://registry.npmjs.org/@rocket.chat/apps-engine/-/apps-engine-1.13.0-beta.3003.tgz",
-			"integrity": "sha512-RGegax9zaDzQta7U1v05JYUgJUhrGlYBYioMdCJRvKs6NrmJNbpdeJ6A0Bu6pNKF9ppMkG17hfxI6xT0MoSd0w==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@rocket.chat/apps-engine/-/apps-engine-1.15.0.tgz",
+			"integrity": "sha512-gwsHa/zTYMmoSG3PP3sZfmVRDRBmIDacOAdCv1FsgJog89ZBCICeoab3VyYAdOMliV5XoygygduYFtc6rinFHQ==",
 			"requires": {
 				"adm-zip": "^0.4.9",
 				"cryptiles": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
 		"@nivo/heatmap": "^0.61.0",
 		"@nivo/line": "^0.61.1",
 		"@nivo/pie": "^0.61.1",
-		"@rocket.chat/apps-engine": "^1.13.0-beta.3003",
+		"@rocket.chat/apps-engine": "^1.15.0",
 		"@rocket.chat/fuselage": "^0.7.1",
 		"@rocket.chat/fuselage-hooks": "^0.7.1",
 		"@rocket.chat/fuselage-polyfills": "^0.7.1",


### PR DESCRIPTION
Upgrades apps-engine to 1.15.0, which is a dependency for the [Dialogflow integration app](https://github.com/RocketChat/Apps.Dialogflow).

