### PR TITLE
Remove department from guest when closing chat.

### DIFF
--- a/app/livechat/server/lib/Livechat.js
+++ b/app/livechat/server/lib/Livechat.js
@@ -345,6 +345,14 @@ export const Livechat = {
 
 		const params = callbacks.run('livechat.beforeCloseRoom', { room, options });
 		const { extraData } = params;
+		const guest = LivechatVisitors.findOneById(room.v._id);
+		const updateUser = {};
+
+		// remove department from guest when closing chat.
+		if (guest.department) {
+			Object.assign(updateUser, { $unset: { department: 1 } });
+			LivechatVisitors.updateById(guest._id, updateUser);
+		}
 
 		const now = new Date();
 		const { _id: rid, servedBy, transcriptRequest } = room;


### PR DESCRIPTION
Closes https://github.com/WideChat/Rocket.Chat/issues/468. 

The main issue was that when the chat was forwarded to a bot of a department, the department is stored in the guest user (visitor). So the next time when chat window opens, the room is directly forwarded to the department, thus escalating the chat. 