### PR TITLE
include apt-get upgrade in dockerfile

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -8,6 +8,7 @@ RUN groupadd -g 65533 -r rocketchat \
     && mkdir -p /app/uploads \
     && chown rocketchat:rocketchat /app/uploads \
     && apt-get update \
+    && apt-get -y upgrade \
     && apt-get install -y --no-install-recommends fontconfig
 
 # --chown requires Docker 17.12 and works only on Linux


### PR DESCRIPTION
using `apt-get upgrade` in order to remove some security vulnerabilities found in twistlock scans.